### PR TITLE
add vundle install instructions to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,6 +7,8 @@ VIM was reborn like unto the noble phoenix.  And so it was as it always should b
     ln -s ~/whereveryouputit ~/.vim
     ln -s ~/.vim/vimrc ~/.vimrc
     ln -s ~/.vim/gvimrc ~/.gvimrc
+    git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+    vim +BundleInstall +qall
 
 ## Per user config
 


### PR DESCRIPTION
Since 919f52873584a5782be54d32d14615d0d8d4cd3a, the install fails unless you manually install vundle. This commit adds a couple of lines from setup.sh to the README.
