### PR TITLE
Update unite.vim config for plugin api changes

### DIFF
--- a/plugin_config.vim
+++ b/plugin_config.vim
@@ -38,9 +38,9 @@ let g:unite_source_session_enable_auto_save = 1
 call unite#filters#matcher_default#use(['matcher_fuzzy'])
 call unite#filters#sorter_default#use(['sorter_rank'])
 
-call unite#set_profile('files', 'ignorecase', 1)
-call unite#set_profile('buffer', 'ignorecase', 1)
-call unite#set_profile('tag', 'ignorecase', 1)
+call unite#custom#profile('files', 'context.ignorecase', 1)
+call unite#custom#profile('buffer', 'context.ignorecase', 1)
+call unite#custom#profile('tag', 'context.ignorecase', 1)
 
 " sort file results by length
 " call unite#custom_source('file_rec/async', 'sorters', 'sorter_length')


### PR DESCRIPTION
I looked through [unite.vim commits](https://github.com/Shougo/unite.vim/commits/master) for a bit to see where this changed, but got bored. This PR removes the following errors when starting vim:

```
~/projects/foo /master> vim README.markdown
[unite.vim] You cannot set "ignorecase". Please set "context.ignorecase" by unite#custom#profile() instead.
[unite.vim] You cannot set "ignorecase". Please set "context.ignorecase" by unite#custom#profile() instead.
[unite.vim] You cannot set "ignorecase". Please set "context.ignorecase" by unite#custom#profile() instead.
Press ENTER or type command to continue
```

The errors are coming from https://github.com/Shougo/unite.vim/blob/1c8d3cb70f33766fb844fac10031902ce3ab1f2a/autoload/unite/custom.vim#L72 in unite.vim.

Technically, I'm only _assuming_ this preserves the desired configured behavior. :trollface: 
